### PR TITLE
Update package versions and change target frameworks +semver:breaking

### DIFF
--- a/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Applications/Application.cs
+++ b/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Applications/Application.cs
@@ -4,6 +4,7 @@ using Aquality.Selenium.Core.Configurations;
 using Aquality.Selenium.Core.Localization;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.Service;
 using System;
 
@@ -55,6 +56,11 @@ namespace Aquality.Appium.Mobile.Applications
             localizedLogger.Info("loc.application.quit");
             Driver?.Quit();
             DriverService?.Dispose();
+        }
+
+        public bool TerminateApp(string bundleId)
+        {
+            return ((IInteractsWithApps)Driver).TerminateApp(bundleId);
         }
     }
 }

--- a/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Applications/IMobileApplication.cs
+++ b/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Applications/IMobileApplication.cs
@@ -20,6 +20,13 @@ namespace Aquality.Appium.Mobile.Applications
         void Quit();
 
         /// <summary>
+        /// Terminate the particular application if it is running.
+        /// </summary>
+        /// <param name="bundleId">the bundle identifier (or app id) of the app to be terminated.</param>
+        /// <returns>true if the app was running before and has been successfully stopped.</returns>
+        bool TerminateApp(string bundleId);
+
+        /// <summary>
         /// Provides current AppiumDriver service instance (would be null if driver is not local).
         /// </summary>
         AppiumLocalService DriverService { get; }

--- a/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Aquality.Appium.Mobile.csproj
+++ b/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Aquality.Appium.Mobile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -14,7 +14,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>appium mobile ios android automation</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Copyright>Copyright 2023 Aquality Automation</Copyright>
+    <Copyright>Copyright 2024 Aquality Automation</Copyright>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
     
@@ -49,8 +49,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.2" />
-    <PackageReference Include="Aquality.Selenium.Core" Version="3.0.5" />
+    <PackageReference Include="Appium.WebDriver" Version="[5.0.0-rc.7, 5.0.0]" />
+    <PackageReference Include="Aquality.Selenium.Core" Version="[3.0.7, 4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Aquality.Appium.Mobile.xml
+++ b/Aquality.Appium.Mobile/src/Aquality.Appium.Mobile/Aquality.Appium.Mobile.xml
@@ -114,6 +114,13 @@
             Closes application and disposes <see cref="P:Aquality.Appium.Mobile.Applications.IMobileApplication.DriverService"/> if it not null.
             </summary>
         </member>
+        <member name="M:Aquality.Appium.Mobile.Applications.IMobileApplication.TerminateApp(System.String)">
+            <summary>
+            Terminate the particular application if it is running.
+            </summary>
+            <param name="bundleId">the bundle identifier (or app id) of the app to be terminated.</param>
+            <returns>true if the app was running before and has been successfully stopped.</returns>
+        </member>
         <member name="P:Aquality.Appium.Mobile.Applications.IMobileApplication.DriverService">
             <summary>
             Provides current AppiumDriver service instance (would be null if driver is not local).

--- a/Aquality.Appium.Mobile/tests/Aquality.Appium.Mobile.Tests/Aquality.Appium.Mobile.Tests.csproj
+++ b/Aquality.Appium.Mobile/tests/Aquality.Appium.Mobile.Tests/Aquality.Appium.Mobile.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Aquality.Appium.Mobile/tests/Aquality.Appium.Mobile.Tests/Aquality.Appium.Mobile.Tests.csproj
+++ b/Aquality.Appium.Mobile/tests/Aquality.Appium.Mobile.Tests/Aquality.Appium.Mobile.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 
     <IsPackable>false</IsPackable>

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Aquality Automation
+   Copyright 2024 Aquality Automation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,10 @@ stages:
           sonar.coverage.exclusions=**/**
           
     - task: UseDotNet@2
-      displayName: Use .NET 6.0
+      displayName: Use .NET 8.0
       inputs:
         packageType: 'sdk'
-        version: '6.0.x'
+        version: '8.0.x'
     
     - task: DotNetCoreCLI@2
       displayName: 'Build solution'
@@ -118,13 +118,14 @@ stages:
       condition: and(succeeded(), eq(variables['isRemote'], 'true'))
           
     - task: UseDotNet@2
-      displayName: Use .NET 6.0
+      displayName: Use .NET 8.0
       inputs:
         packageType: 'sdk'
-        version: '6.0.x'
+        version: '8.0.x'
         
     - task: DotNetCoreCLI@2
       displayName: 'Run tests'
+      retryCountOnTaskFailure: 1
       inputs:
         command: 'test'
         projects: '**/*Tests*/*.csproj'
@@ -157,10 +158,10 @@ stages:
 
     steps:          
     - task: UseDotNet@2
-      displayName: Use .NET 6.0
+      displayName: Use .NET 8.0
       inputs:
         packageType: 'sdk'
-        version: '6.0.x'
+        version: '8.0.x'
 
     - task: gitversion/setup@0
       displayName: 'Install GitTools'


### PR DESCRIPTION
- Update to Appium.WebDriver v.5.0.0-rc-7 and Selenium v.4.19.0. Use version range
- Change target frameworks to be .NET 6 and .NET 4.8 instead of .NET Standard
- Update Copyright year in csproj and in License
- Migrate to .NET 8.0 and update pipeline, retry for tests added
- added a method to terminate specific applications by their bundle identifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated support for newer .NET frameworks to enhance compatibility.

- **Documentation**
	- Updated copyright year in the license information.

- **Chores**
	- Updated package versions to improve stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->